### PR TITLE
squid:S00117 - Local variable and method parameter names should compl…

### DIFF
--- a/app/src/main/java/victoralbertos/io/rxgcm/presentation/ChildFragment.java
+++ b/app/src/main/java/victoralbertos/io/rxgcm/presentation/ChildFragment.java
@@ -1,0 +1,37 @@
+package victoralbertos.io.rxgcm.presentation;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import rx.Observable;
+import rx_gcm.ForegroundMessage;
+import rx_gcm.GcmForegroundReceiver;
+import victoralbertos.io.rxgcm.BackgroundMessageReceiver;
+import victoralbertos.io.rxgcm.R;
+
+/**
+ * Created by victor on 08/02/16.
+ */
+public class ChildFragment extends Fragment implements GcmForegroundReceiver {
+
+    @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_main, container, false);
+    }
+
+    @Override public void onReceiveMessage(Observable<ForegroundMessage> oMessage) {
+        final TextView tvTitle = (TextView) getView().findViewById(R.id.tv_title_fragment);
+        final TextView tvBody = (TextView) getView().findViewById(R.id.tv_body_fragment);
+
+        oMessage.doOnError(error -> tvTitle.setText(error.getMessage()))
+                .subscribe(message -> {
+                    String title = message.getPayload().getString(BackgroundMessageReceiver.TITLE);
+                    tvTitle.setText(title);
+                    String body = message.getPayload().getString(BackgroundMessageReceiver.BODY);
+                    tvBody.setText(body);
+                });
+    }
+}

--- a/app/src/main/java/victoralbertos/io/rxgcm/presentation/MainActivity.java
+++ b/app/src/main/java/victoralbertos/io/rxgcm/presentation/MainActivity.java
@@ -1,0 +1,60 @@
+package victoralbertos.io.rxgcm.presentation;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import rx.Observable;
+import rx_gcm.ForegroundMessage;
+import rx_gcm.GcmForegroundReceiver;
+import victoralbertos.io.rxgcm.BackgroundMessageReceiver;
+import victoralbertos.io.rxgcm.R;
+import victoralbertos.io.rxgcm.api.GcmServerService;
+
+public class MainActivity extends AppCompatActivity implements GcmForegroundReceiver {
+    private GcmServerService gcmServerService;
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        sendMessageClick();
+        gcmServerService = new GcmServerService();
+    }
+
+    private void sendMessageClick() {
+        findViewById(R.id.bt_send_notification).setOnClickListener(view -> {
+            String title = ((EditText) findViewById(R.id.et_title)).getText().toString();
+            String body = ((EditText) findViewById(R.id.et_body)).getText().toString();
+
+            gcmServerService.sendGcmNotification(title, body).subscribe(success -> {
+                if (success) Log.d("sendGcmNotification", "Message sent");
+                else Log.e("sendGcmNotification", "Message not sent");
+            });
+        });
+    }
+
+    @Override public void onReceiveMessage(Observable<ForegroundMessage> oMessage) {
+        final TextView tvTitle = (TextView) findViewById(R.id.tv_title_activity);
+        final TextView tvBody = (TextView) findViewById(R.id.tv_body_activity);
+
+        oMessage.doOnError(error -> tvTitle.setText(error.getMessage()))
+                .subscribe(message -> {
+                    String title = message.getPayload().getString(BackgroundMessageReceiver.TITLE);
+                    tvTitle.setText(title);
+                    String body = message.getPayload().getString(BackgroundMessageReceiver.BODY);
+                    tvBody.setText(body);
+                });
+    }
+
+    public void receivedFromCentralized(ForegroundMessage message) {
+        final TextView tvTitle = (TextView) findViewById(R.id.tv_title_centralized);
+        final TextView tvBody = (TextView) findViewById(R.id.tv_body_centralized);
+
+        String title = message.getPayload().getString(BackgroundMessageReceiver.TITLE);
+        tvTitle.setText(title);
+        String body = message.getPayload().getString(BackgroundMessageReceiver.BODY);
+        tvBody.setText(body);
+    }
+}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00117 - Local variable and method parameter names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00117

Please let me know if you have any questions.

M-Ezzat
